### PR TITLE
Feature: Store incoming schedules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2.1.1
+- Add ability to store schedules created by Centry Portal.
+
 2.1.0
 - Add a setting to enable API token regeneration.
 - Save the regenerated API token after a successful subscription request.

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "minimum-stability": "stable",
     "require": {
-        "concrete5/core": "^8.2"
+        "concrete5/core": "^8.2",
+        "dragonmantank/cron-expression": "dev-master#v1.2.0"
     }
 }

--- a/controller.php
+++ b/controller.php
@@ -18,7 +18,7 @@ final class Controller extends Package
 {
     protected $pkgHandle = 'centry';
     protected $appVersionRequired = '8.0';
-    protected $pkgVersion = '2.1.0';
+    protected $pkgVersion = '2.1.1';
     protected $pkgAutoloaderRegistries = [
         'src/Centry' => '\A3020\Centry',
     ];

--- a/controller.php
+++ b/controller.php
@@ -31,6 +31,8 @@ final class Controller extends Package
 
     public function on_start()
     {
+        $this->loadDependencies();
+
         $this->config = $this->app->make(Repository::class);
 
         $this->saveDomain();
@@ -166,5 +168,19 @@ final class Controller extends Package
 
         $db = $this->app->make('database')->connection();
         $db->executeQuery("DROP TABLE IF EXISTS CentrySchedules");
+    }
+
+    /**
+     * Load Composer files.
+     *
+     * If the C5 installation is Composer based, the vendor directory will
+     * be in the root directory. Therefore we first check if it's present.
+     */
+    private function loadDependencies()
+    {
+        $autoloadFile = $this->getPackagePath() . '/vendor/autoload.php';
+        if (file_exists($autoloadFile)) {
+            require_once $autoloadFile;
+        }
     }
 }

--- a/controller.php
+++ b/controller.php
@@ -159,4 +159,12 @@ final class Controller extends Package
             $this->config->save('centry.identifier', str_random(32));
         }
     }
+
+    public function uninstall()
+    {
+        parent::uninstall();
+
+        $db = $this->app->make('database')->connection();
+        $db->executeQuery("DROP TABLE IF EXISTS CentrySchedules");
+    }
 }

--- a/controllers/api/api.php
+++ b/controllers/api/api.php
@@ -2,31 +2,10 @@
 
 namespace Concrete\Package\Centry\Controller\Api;
 
-use Concrete\Core\Config\Repository\Repository;
-use Concrete\Core\Controller\Controller;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use A3020\Centry\Controller\ApiBase;
 
-class Api extends Controller
+class Api extends ApiBase
 {
-    public function invoke($method)
-    {
-        if (!$this->isMethodAllowed($method)) {
-            return new JsonResponse([
-                'error' => t('Method Not Allowed'),
-            ], 405);
-        }
-
-        if (!$this->isMethodImplemented($method)) {
-            return new JsonResponse([
-                'error' => t('Method Not Implemented'),
-            ], 501);
-        }
-
-        $response = new JsonResponse($this->{$method}());
-        $response->send();
-        exit;
-    }
-
     /**
      * @todo to be implemented
      */
@@ -85,27 +64,9 @@ class Api extends Controller
         return $this->app->make(\A3020\Centry\Log\Summary\Payload::class);
     }
 
-    /**
-     * Return false if method is disabled via the config.
-     *
-     * @param string $method
-     * @return bool
-     */
-    private function isMethodAllowed($method)
+    protected function schedules__post()
     {
-        $config = $this->app->make(Repository::class);
-
-        return (bool) $config->get('centry.api.methods.'.$method, true);
-    }
-
-    /**
-     * Return false if the method is not implemented.
-     *
-     * @param string $method
-     * @return bool
-     */
-    private function isMethodImplemented($method)
-    {
-        return method_exists($this, $method);
+        $controller = $this->app->make(\A3020\Centry\Schedule\StoreSchedules::class);
+        return $controller->handle();
     }
 }

--- a/controllers/single_page/dashboard/system/centry.php
+++ b/controllers/single_page/dashboard/system/centry.php
@@ -5,7 +5,6 @@ namespace Concrete\Package\Centry\Controller\SinglePage\Dashboard\System;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Job\Job;
 use Concrete\Core\Page\Controller\DashboardPageController;
-use Concrete\Core\Url\Resolver\CanonicalUrlResolver;
 use Concrete\Core\Url\Resolver\PathUrlResolver;
 
 final class Centry extends DashboardPageController
@@ -155,6 +154,8 @@ final class Centry extends DashboardPageController
             'files_summary' => t('Files summary'),
             'users_summary' => t('Users summary'),
             'logs_summary' => t('Logs summary'),
+            'schedules' => t('Schedules'),
+            'schedules__post' => t('Schedules (write)'),
         ];
     }
 

--- a/src/Centry/Controller/ApiBase.php
+++ b/src/Centry/Controller/ApiBase.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace A3020\Centry\Controller;
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class ApiBase extends Controller
+{
+    public function invoke($method)
+    {
+        $verb = $this->getHttpVerb();
+        $method = $verb !== 'get' ? $method.'__'.$verb : $method;
+
+        if (!$this->isMethodAllowed($method)) {
+            return new JsonResponse([
+                'error' => t('Method Not Allowed'),
+            ], 405);
+        }
+
+        if (!$this->isMethodImplemented($method)) {
+            return new JsonResponse([
+                'error' => t('Method Not Implemented'),
+            ], 501);
+        }
+
+        $response = new JsonResponse($this->{$method}());
+        $response->send();
+        exit;
+    }
+
+    /**
+     * Return false if method is disabled via the config.
+     *
+     * @param string $method
+     * @return bool
+     */
+    private function isMethodAllowed($method)
+    {
+        $config = $this->app->make(Repository::class);
+
+        return (bool) $config->get('centry.api.methods.'.$method, true);
+    }
+
+    /**
+     * Return false if the method is not implemented.
+     *
+     * @param string $method
+     * @return bool
+     */
+    private function isMethodImplemented($method)
+    {
+        return method_exists($this, $method);
+    }
+
+    /**
+     * Returns e.g. 'get', or 'post'.
+     *
+     * @return string
+     */
+    private function getHttpVerb()
+    {
+        if ($this->request->isPost()) {
+            $verb = 'post';
+        }
+
+        return $verb ?? 'get';
+    }
+}

--- a/src/Centry/Entity/Schedule.php
+++ b/src/Centry/Entity/Schedule.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace A3020\Centry\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(
+ *   name="CentrySchedules",
+ * )
+ */
+class Schedule
+{
+    /**
+     * @ORM\Id @ORM\Column(type="guid")
+     * @ORM\GeneratedValue(strategy="UUID")
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(type="string", nullable=false)
+     */
+    protected $cronExpression = '';
+
+    /**
+     * @ORM\Column(type="json_array", nullable=false)
+     */
+    protected $jobHandles = [];
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return (int) $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCronExpression()
+    {
+        return (string) $this->cronExpression;
+    }
+
+    /**
+     * @return array
+     */
+    public function getJobHandles()
+    {
+        return (array) $this->jobHandles;
+    }
+
+    /**
+     * @param string $cronExpression
+     */
+    public function setCronExpression($cronExpression)
+    {
+        $this->cronExpression = (string) $cronExpression;
+    }
+
+    /**
+     * @param array $jobHandles
+     */
+    public function setJobHandles($jobHandles)
+    {
+        $this->jobHandles = (array) $jobHandles;
+    }
+}

--- a/src/Centry/Exception/InvalidScheduleException.php
+++ b/src/Centry/Exception/InvalidScheduleException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace A3020\Centry\Exception;
+
+use Exception;
+
+class InvalidScheduleException extends Exception
+{
+    public static function invalidPayload()
+    {
+        return new static(t('Invalid schedule(s)'));
+    }
+
+    public static function invalidCronExpression()
+    {
+        return new static(t('Invalid cron expression(s)'));
+    }
+
+    public static function invalidJobHandle()
+    {
+        return new static(t('Invalid job handle(s)'));
+    }
+}

--- a/src/Centry/Schedule/StoreSchedules.php
+++ b/src/Centry/Schedule/StoreSchedules.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace A3020\Centry\Schedule;
+
+use A3020\Centry\Entity\Schedule;
+use A3020\Centry\Exception\InvalidScheduleException;
+use Concrete\Core\Http\Request;
+use Cron\CronExpression;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+
+class StoreSchedules
+{
+    /** @var Request */
+    private $request;
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(Request $request, EntityManagerInterface $entityManager)
+    {
+        $this->request = $request;
+        $this->entityManager = $entityManager;
+    }
+
+    public function handle()
+    {
+        try {
+            $content = $this->request->getContent();
+            $schedules = json_decode($content, true);
+
+            $this->validate($schedules);
+            $this->deleteOldSchedules();
+            $this->storeSchedules($schedules);
+        } catch (Exception $e) {
+            return [
+                'error' => $e->getMessage(),
+            ];
+        }
+
+        return [
+            'error' => false,
+        ];
+    }
+
+    private function deleteOldSchedules()
+    {
+        $entities = $this->entityManager->getRepository(Schedule::class)
+            ->findAll();
+        array_walk($entities, function($entity) {
+            $this->entityManager->remove($entity);
+        });
+
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @param array $schedules
+     */
+    private function storeSchedules($schedules)
+    {
+        foreach ($schedules as $schedule) {
+            $entity = new Schedule();
+            $entity->setCronExpression($schedule['cron_expression']);
+            $entity->setJobHandles($schedule['job_handles']);
+            $this->entityManager->persist($entity);
+        }
+
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @param array $schedules
+     * @throws InvalidScheduleException
+     */
+    private function validate($schedules)
+    {
+        if (!is_array($schedules)) {
+            throw InvalidScheduleException::invalidPayload();
+        }
+
+        foreach ($schedules as $schedule) {
+            if (!isset($schedule['cron_expression'])) {
+                throw InvalidScheduleException::invalidCronExpression();
+            }
+
+            if (!CronExpression::isValidExpression($schedule['cron_expression'])) {
+                throw InvalidScheduleException::invalidCronExpression();
+            }
+
+            if (!isset($schedule['job_handles']) || !is_array($schedule['job_handles'])) {
+                throw InvalidScheduleException::invalidJobHandle();
+            }
+
+            // Do not allow multidimensional a job handles array
+            foreach ($schedule['job_handles'] as $jobHandle) {
+                if (is_array($jobHandle)) {
+                    throw InvalidScheduleException::invalidJobHandle();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR:
- Creates a table "CentrySchedules".
- Validates and stores incoming schedules.
- Adds a cron expression library that's compatible with PHP 5.6.
- Adds support for POST calls to the API.

Related: #3 