### PR TITLE
Feature/add command to execute schedules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2.1.2
+- Use a service provider to bootstrap the package.
+- Add a console command to run schedules.
+
 2.1.1
 - Add ability to store schedules created by Centry Portal.
 

--- a/controller.php
+++ b/controller.php
@@ -14,7 +14,7 @@ final class Controller extends Package
 {
     protected $pkgHandle = 'centry';
     protected $appVersionRequired = '8.0';
-    protected $pkgVersion = '2.1.1';
+    protected $pkgVersion = '2.1.2';
     protected $pkgAutoloaderRegistries = [
         'src/Centry' => '\A3020\Centry',
     ];

--- a/src/Centry/Console/Command/RunSchedulesCommand.php
+++ b/src/Centry/Console/Command/RunSchedulesCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace A3020\Centry\Console\Command;
+
+use A3020\Centry\Entity\Schedule;
+use Concrete\Core\Console\Command;
+use Concrete\Core\Console\ConsoleAwareInterface;
+use Concrete\Core\Job\Job;
+use Concrete\Core\Support\Facade\Application;
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RunSchedulesCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('centry:run-schedules')
+            ->setDescription('Run automated job schedules');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $app = Application::getFacadeApplication();
+        $em = $app->make(EntityManager::class);
+
+        $schedules = $em->getRepository(Schedule::class)
+            ->findAll();
+
+        foreach ($schedules as $schedule) {
+            $this->runSchedule($schedule, $input, $output);
+        }
+    }
+
+    private function runSchedule(Schedule $schedule, InputInterface $input, OutputInterface $output)
+    {
+        if ($schedule->isDue() === false) {
+            return;
+        }
+
+        $formatter = $this->getHelper('formatter');
+        foreach ($this->getJobs($schedule) as $job) {
+            /** @var Job $job */
+
+            // Provide the console objects to objects that are aware of the console
+            if ($job instanceof ConsoleAwareInterface) {
+                $job->setConsole($this->getApplication(), $output, $input);
+            }
+
+            $result = $job->executeJob();
+            if ($result->isError()) {
+                if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
+                    $output->writeln(
+                        $formatter->formatSection(
+                            $job->getJobHandle(), '<error>' . t('Job Failed') . '</error>'
+                        )
+                    );
+                }
+            }
+
+            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
+                $output->writeln(
+                    $formatter->formatSection($job->getJobHandle(), $result->getResultMessage())
+                );
+            }
+        }
+    }
+
+    /**
+     * Generator for Job objects.
+     *
+     * We skip jobs that are 'running'.
+     *
+     * @param Schedule $schedule
+     * @return \Generator
+     */
+    private function getJobs(Schedule $schedule)
+    {
+        foreach ($schedule->getJobHandles() as $handle) {
+            /** @var Job $job */
+            $job = Job::getByHandle($handle);
+            if (!$job) {
+                continue;
+            }
+
+            if ($job->getJobStatus() === 'RUNNING') {
+                continue;
+            }
+
+            yield $job;
+        }
+    }
+}

--- a/src/Centry/Entity/Schedule.php
+++ b/src/Centry/Entity/Schedule.php
@@ -2,6 +2,7 @@
 
 namespace A3020\Centry\Entity;
 
+use Cron\CronExpression;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -66,5 +67,16 @@ class Schedule
     public function setJobHandles($jobHandles)
     {
         $this->jobHandles = (array) $jobHandles;
+    }
+
+    /**
+     * Returns true if we need to run this Schedule.
+     *
+     * @return bool
+     */
+    public function isDue()
+    {
+        $cron = CronExpression::factory($this->getCronExpression());
+        return $cron->isDue();
     }
 }

--- a/src/Centry/Provider/CentryServiceProvider.php
+++ b/src/Centry/Provider/CentryServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace A3020\Centry\Provider;
 
+use A3020\Centry\Console\Command\RunSchedulesCommand;
 use A3020\Centry\Http\Middleware\CentryApiTokenMiddleware;
 use A3020\Centry\Http\Middleware\CentryEnabledMiddleware;
 use Concrete\Core\Application\Application;
@@ -32,6 +33,10 @@ class CentryServiceProvider
 
         $this->registerMiddleware();
         $this->registerRoutes();
+
+        if ($this->app->isRunThroughCommandLineInterface()) {
+            $this->registerConsoleCommands();
+        }
     }
 
     /**
@@ -57,6 +62,12 @@ class CentryServiceProvider
             $api = $this->app->make(Api::class);
             return $api->invoke($method);
         });
+    }
+
+    private function registerConsoleCommands()
+    {
+        $console = $this->app->make('console');
+        $console->add(new RunSchedulesCommand());
     }
 
     /**


### PR DESCRIPTION
This PR adds a CLI command to execute schedules. `centry:run-schedules`.

Working:
Each schedule's cron expression is evaluated. If a schedule needs to be run, the corresponding jobs are retrieved and executed if they exist and are not running already.

Related: https://github.com/a3020/centry/issues/3