### PR TITLE
Add document root to environment call

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2.1.3
+- Add document root path to 'environment' API call.
+
 2.1.2
 - Use a service provider to bootstrap the package.
 - Add a console command to run schedules.

--- a/controller.php
+++ b/controller.php
@@ -14,7 +14,7 @@ final class Controller extends Package
 {
     protected $pkgHandle = 'centry';
     protected $appVersionRequired = '8.0';
-    protected $pkgVersion = '2.1.2';
+    protected $pkgVersion = '2.1.3';
     protected $pkgAutoloaderRegistries = [
         'src/Centry' => '\A3020\Centry',
     ];

--- a/src/Centry/Environment/Payload.php
+++ b/src/Centry/Environment/Payload.php
@@ -27,6 +27,7 @@ final class Payload extends PayloadAbstract
             'php_version' => $this->getPhpVersion(),
             'ip_address' => $this->getIpAddress(),
             'overrides' => $this->getOverrides(),
+            'document_root' => $this->getDocumentRoot(),
         ];
     }
 
@@ -56,5 +57,17 @@ final class Payload extends PayloadAbstract
         }
 
         return explode(', ', $info->getOverrides());
+    }
+
+    /**
+     * Return DocumentRoot of current installation.
+     *
+     * Available from version 2.1.3.
+     *
+     * @return string
+     */
+    private function getDocumentRoot()
+    {
+        return (string) $_SERVER["DOCUMENT_ROOT"];
     }
 }


### PR DESCRIPTION
Example output of 'environment' call:

```
{
    "c5_version": "8.3.0a1",
    "php_version": "7.1.8",
    "ip_address": "127.0.0.1",
    "overrides": [],
    "document_root": "C:/dev/web"
}
```

Related: https://github.com/a3020/centry/issues/6