### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2.1.6
+- Use a3020 cron expression dependency, to fix composer problems regarding minimum stability.
+
 2.1.5
 - Fix PHP 5.6 compatibility.
 

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,6 @@
     "minimum-stability": "stable",
     "require": {
         "concrete5/core": "^8.2",
-        "dragonmantank/cron-expression": "dev-master#v1.2.0"
+        "a3020/cron-expression": "^1.2"
     }
 }

--- a/controller.php
+++ b/controller.php
@@ -14,7 +14,7 @@ final class Controller extends Package
 {
     protected $pkgHandle = 'centry';
     protected $appVersionRequired = '8.0';
-    protected $pkgVersion = '2.1.5';
+    protected $pkgVersion = '2.1.6';
     protected $pkgAutoloaderRegistries = [
         'src/Centry' => '\A3020\Centry',
     ];


### PR DESCRIPTION
The dragonmantank/cron-expression has a minimum PHP version of 5.3. However, concrete5 8.2 uses 5.6, so that will conflict during composer install.

Therefore we use a 'fork' of the [cron_expression library.](https://github.com/a3020/cron-expression)